### PR TITLE
Make URLs in chat messages wrap and clickable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@tailwindcss/postcss": "^4.1.10",
         "dotenv-webpack": "^8.1.0",
+        "linkify-react": "^4.3.2",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-hot-toast": "^2.5.2",
@@ -2909,6 +2910,23 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/linkify-react": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/linkify-react/-/linkify-react-4.3.2.tgz",
+      "integrity": "sha512-mi744h1hf+WDsr+paJgSBBgYNLMWNSHyM9V9LVUo03RidNGdw1VpI7Twnt+K3pEh3nIzB4xiiAgZxpd61ItKpQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "linkifyjs": "^4.0.0",
+        "react": ">= 15.0.0"
+      }
+    },
+    "node_modules/linkifyjs": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.2.tgz",
+      "integrity": "sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/loader-runner": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "@tailwindcss/postcss": "^4.1.10",
     "dotenv-webpack": "^8.1.0",
+    "linkify-react": "^4.3.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-hot-toast": "^2.5.2",

--- a/src/popup/components/inbox/MessageItem.tsx
+++ b/src/popup/components/inbox/MessageItem.tsx
@@ -1,3 +1,5 @@
+import Linkify from 'linkify-react';
+
 interface MessageItemProps {
   message: any;
   isOwn: boolean;
@@ -32,8 +34,17 @@ const MessageItem = ({
             {message.sender.displayName || message.sender.username}
           </div>
         )}
-        
-        <div className="text-sm">{message.content}</div>
+        <div className="text-sm break-words">
+            <Linkify
+            options={{
+               className: 'underline',
+              target: '_blank',
+              rel: 'noopener noreferrer',
+            }}
+          >
+            {message.content}
+          </Linkify>
+        </div>
         
         <div className={`flex items-center justify-between mt-2 ${
           isOwn ? 'flex-row-reverse' : 'flex-row'


### PR DESCRIPTION
Closes #6 
This PR fixes 
1. Ensuring long text and URLs wrap correctly within the message container.
2. Detecting URLs inside chat message text and rendering them as clickable links with underline.
3. Opening the URLs in a new tab on clicking.

![clickable_urls](https://github.com/user-attachments/assets/aa9d3450-563a-41da-bf0f-683308cf245b)

