### PR TITLE
fix(login): send client timezone for analytics requests

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -215,11 +215,16 @@ export const flushAnalytics = async (token: string) => {
 };
 
 export async function fetchHourlyPresence(token: string, days = 7) {
-  const res = await fetch(`${BACKEND_URL}/api/analytics/presence/hourly?days=${days}`, {
-    headers: { Authorization: `Bearer ${token}` }
-  });
+  const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const res = await fetch(
+    `${BACKEND_URL}/api/analytics/presence/hourly?days=${days}&timezone=${encodeURIComponent(timezone)}`,
+    {
+      headers: { Authorization: `Bearer ${token}` }
+    }
+  );
   return res.json();
 }
+
 
 export async function fetchLeaderboard(token: string, page = 1, limit = 10, month?: string) {
   const params = new URLSearchParams({

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -188,11 +188,16 @@ export const fetchUserProfile = async (username: string, token: string) => {
 };
 
 export const fetchWeeklyTabUsage = async (token: string) => {
-  const res = await fetch(`${BACKEND_URL}/api/analytics/tab-usage/weekly`, {
-    headers: { Authorization: `Bearer ${token}` }
-  });
-  return await res.json();
+  const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+  const res = await fetch(
+    `${BACKEND_URL}/api/analytics/tab-usage/weekly?timezone=${encodeURIComponent(timezone)}`,
+    { headers: { Authorization: `Bearer ${token}` } }
+  );
+
+  return res.json();
 };
+
 
 export const updatePrivacySettings = async (data: any, token: string) => {
   const res = await fetch(`${BACKEND_URL}/api/profile/privacy`, {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -195,7 +195,7 @@ export const fetchWeeklyTabUsage = async (token: string) => {
     { headers: { Authorization: `Bearer ${token}` } }
   );
 
-  return res.json();
+  return await res.json();
 };
 
 


### PR DESCRIPTION
## Description

This PR updates the frontend to send the user’s local timezone with analytics API requests so that analytics data (especially hourly presence) is calculated correctly on the backend.

This change is the frontend counterpart to the server-side fix introduced in PR https://github.com/browseping/server/pull/20 (`fix(analytics): correct hourly presence using user timezone`).

---

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

---

## Related Issue

---

## Changes Made

- Added user timezone using `Intl.DateTimeFormat().resolvedOptions().timeZone`
- Updated `fetchHourlyPresence` API call to include `timezone` as a query parameter
- Ensured changes are limited to analytics-related requests only
- No impact on authentication or other API calls

---

## Testing Done

- Logged in and triggered analytics requests from the frontend
- Verified timezone is correctly sent in the request query
- Confirmed backend returns different hourly data for different timezones (Asia/Kolkata vs Asia/Tokyo)
- Verified no regressions in existing functionality

---

## Checklist

- [x] **I have read and followed all guidelines in [CONTRIBUTING.md](CONTRIBUTING.md)**
- [x] I have used the correct branch naming convention (`fix/login-send-timezone`)
- [x] My commits follow Conventional Commits format (`fix:`)
- [x] I have performed a self-review and tested my changes thoroughly
- [x] **CRITICAL**: I confirm ONLY my intended changes are included
- [x] No documentation update required

---

## Screenshots (if applicable)

Not applicable — no UI changes.

---

## Additional Notes

This PR complements the backend analytics timezone fix by ensuring the frontend sends the correct user timezone without introducing additional logic on the client side.
